### PR TITLE
feat: add spell checker for English

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,6 +431,7 @@
         "plenary.nvim": "plenary.nvim",
         "satellite.nvim": "satellite.nvim",
         "snacks.nvim": "snacks.nvim",
+        "spellwarn.nvim": "spellwarn.nvim",
         "which-key.nvim": "which-key.nvim"
       }
     },
@@ -463,6 +464,22 @@
       "original": {
         "owner": "folke",
         "repo": "snacks.nvim",
+        "type": "github"
+      }
+    },
+    "spellwarn.nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756861421,
+        "narHash": "sha256-c7pjWmhRqNAuJ2rq4lsrFLEM9Ypdi7eUQ08CCqXl9M0=",
+        "owner": "ravibrock",
+        "repo": "spellwarn.nvim",
+        "rev": "ef6a121b2fec1c4474427c6ccfd489338eb53a5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ravibrock",
+        "repo": "spellwarn.nvim",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
-
   outputs = {
     self,
     nixpkgs,
@@ -206,6 +205,10 @@
     };
     "snacks.nvim" = {
       url = "github:folke/snacks.nvim";
+      flake = false;
+    };
+    "spellwarn.nvim" = {
+      url = "github:ravibrock/spellwarn.nvim";
       flake = false;
     };
     "which-key.nvim" = {

--- a/lua/plugins/spellwarn.lua
+++ b/lua/plugins/spellwarn.lua
@@ -1,0 +1,53 @@
+--[[
+-- Spell checker plugin set for English
+--
+-- Usage:
+--      ]s            -> jump to next misspelled word
+--      [s            -> jump to previous misspelled word
+--      z=            -> show spelling suggestions
+--      zg            -> add word to dictionary
+--      zw            -> mark word as wrong
+-- ]]
+
+local opts = {
+    event = { -- event(s) to refresh diagnostics on
+        -- "CursorHold",
+        -- "InsertLeave",
+        "TextChanged",
+        "TextChangedI",
+        "TextChangedP",
+    },
+    enable = true, -- enable diagnostics on startup
+    ft_config = { -- spellcheck method: "cursor", "iter", or boolean
+        alpha = false,
+        help = false,
+        lazy = false,
+        lspinfo = false,
+        mason = false,
+    },
+    ft_default = true, -- default option for unspecified file types
+    max_file_size = 80, -- maximum file size to check in lines (nil for no limit)
+    severity = { -- severity for each spelling error type (false to disable diagnostics for that type)
+        spellbad = "WARN",
+        spellcap = "HINT",
+        spelllocal = "HINT",
+        spellrare = "INFO",
+    },
+    suggest = false, -- show spelling suggestions in diagnostic message (works best with window-style message)
+    num_suggest = 0, -- number of spelling suggestions shown in diagnostic message
+    prefix = "possible misspelling(s): ", -- prefix for each diagnostic message
+    diagnostic_opts = { severity_sort = true }, -- options for diagnostic display
+}
+
+local function config()
+    vim.opt.spell = true
+    vim.opt.spelllang = { "en_us" }
+
+    require("spellwarn").setup(opts)
+end
+
+return {
+    "ravibrock/spellwarn.nvim",
+    lazy = false,
+    config = config,
+}


### PR DESCRIPTION
```
feat: add spell checker for English

    - The plugin `spellwarn` was added, and set to support English.
    - The flake.nix and flake.lock was also update to include the new plugin.
    - A file size limit as added to avoid lag when dealing with large files
    (larger than 80 lines)
```